### PR TITLE
Feature add .net aspire

### DIFF
--- a/Cookbook-Api/Cookbook.Api/Cookbook.Api.csproj
+++ b/Cookbook-Api/Cookbook.Api/Cookbook.Api.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\Cookbook.Application\Cookbook.Application.csproj" />
     <ProjectReference Include="..\Cookbook.Infrastructure\Cookbook.Infrastructure.csproj" />
     <ProjectReference Include="..\Cookbook.Repositories\Cookbook.Repositories.csproj" />
+    <ProjectReference Include="..\Cookbook.ServiceDefaults\Cookbook.ServiceDefaults.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Cookbook-Api/Cookbook.Api/Endpoints/Recipe/RecipeEndpoint.cs
+++ b/Cookbook-Api/Cookbook.Api/Endpoints/Recipe/RecipeEndpoint.cs
@@ -6,6 +6,7 @@ using Cookbook.Application.Recipe.Models;
 using Cookbook.Application.Recipe.Queries;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Cookbook.Api.Endpoints.Recipe;
 
@@ -27,6 +28,7 @@ public class RecipeEndpoint : IEndpoint
 
                 return result.ToMinimalApiResult();
             })
+            .CacheOutput()
             .Produces<IEnumerable<RecipeDto>>();
 
         group.MapGet("/{id:int}", async (IMediator mediator, int id, CancellationToken cancellationToken) =>
@@ -41,6 +43,7 @@ public class RecipeEndpoint : IEndpoint
                     _ => result.ToMinimalApiResult(),
                 };
             })
+            .CacheOutput()
             .Produces<RecipeDto>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesValidationProblem();

--- a/Cookbook-Api/Cookbook.Api/Program.cs
+++ b/Cookbook-Api/Cookbook.Api/Program.cs
@@ -10,7 +10,8 @@ builder.Host.UseSerilog();
 
 builder.AddServiceDefaults();
 builder
-    .AddPersistence();
+    .AddPersistence()
+    .AddRedisOutputCache();
 
 // Add services to the container.
 builder.Services
@@ -33,6 +34,7 @@ app.UseRouting();
 app.UseCors(builder.Configuration.GetValue<string>("AllowedOrigin")!);
 app.UseSwagger();
 app.UseSwaggerUI();
+app.UseOutputCache();
 
 app.UseHealthChecks("/health");
 

--- a/Cookbook-Api/Cookbook.Api/Program.cs
+++ b/Cookbook-Api/Cookbook.Api/Program.cs
@@ -2,16 +2,18 @@ using Cookbook.Api.Extensions;
 using Cookbook.Api.Middlewares;
 using Cookbook.Application;
 using Cookbook.Infrastructure.Persistence;
-using Cookbook.Repositories;
 using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog();
 
+builder.AddServiceDefaults();
+builder
+    .AddPersistence();
+
 // Add services to the container.
 builder.Services
-    .AddPersistence(builder.Configuration.GetValue<string>("ConnectionStrings:Postgres"))
     .AddRepositories()
     .AddApplication()
     .AddApi();

--- a/Cookbook-Api/Cookbook.Api/Program.cs
+++ b/Cookbook-Api/Cookbook.Api/Program.cs
@@ -21,6 +21,9 @@ builder.Services
 
 var app = builder.Build();
 
+// Apply migrations on startup
+await app.ApplyMigrations();
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("Docker"))
 {

--- a/Cookbook-Api/Cookbook.Api/appsettings.json
+++ b/Cookbook-Api/Cookbook.Api/appsettings.json
@@ -1,8 +1,5 @@
 {
   "AllowedOrigin": "https://localhost:5001",
-  "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=54320;Database=cookbook;User Id=postgres;Password=Qwerty123!"
-  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/Cookbook-Api/Cookbook.AppHost/Cookbook.AppHost.csproj
+++ b/Cookbook-Api/Cookbook.AppHost/Cookbook.AppHost.csproj
@@ -9,6 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
+        <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Cookbook.Api\Cookbook.Api.csproj" />
+        <ProjectReference Include="..\Cookbook.ServiceDefaults\Cookbook.ServiceDefaults.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Cookbook-Api/Cookbook.AppHost/Cookbook.AppHost.csproj
+++ b/Cookbook-Api/Cookbook.AppHost/Cookbook.AppHost.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
         <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.0.0" />
+        <PackageReference Include="Aspire.Hosting.Redis" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Cookbook-Api/Cookbook.AppHost/Cookbook.AppHost.csproj
+++ b/Cookbook-Api/Cookbook.AppHost/Cookbook.AppHost.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0"/>
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <IsAspireHost>true</IsAspireHost>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/Cookbook-Api/Cookbook.AppHost/Program.cs
+++ b/Cookbook-Api/Cookbook.AppHost/Program.cs
@@ -7,8 +7,13 @@ var postgres = builder.AddPostgres("postgres")
     .WithEndpoint(name: "postgres", port: 54320, targetPort: 5432, isExternal: true)
     .AddDatabase("cookbook");
 
+var redis = builder.AddRedis("redis")
+    .WithRedisCommander()
+    .WithDataBindMount(source: "../../data/redis");
+
 var api = builder.AddProject<Projects.Cookbook_Api>("api")
     .WaitFor(postgres)
-    .WithReference(postgres);
+    .WithReference(postgres)
+    .WithReference(redis);
 
 await builder.Build().RunAsync();

--- a/Cookbook-Api/Cookbook.AppHost/Program.cs
+++ b/Cookbook-Api/Cookbook.AppHost/Program.cs
@@ -1,0 +1,4 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+
+await builder.Build().RunAsync();

--- a/Cookbook-Api/Cookbook.AppHost/Program.cs
+++ b/Cookbook-Api/Cookbook.AppHost/Program.cs
@@ -1,4 +1,14 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
+var postgres = builder.AddPostgres("postgres")
+    .WithEnvironment("POSTGRES_DB", "cookbook")
+    .WithEnvironment("PGDATA", "/var/lib/postgresql/data/pgdata")
+    .WithDataBindMount(source: "../../data/postgres")
+    .WithEndpoint(name: "postgres", port: 54320, targetPort: 5432, isExternal: true)
+    .AddDatabase("cookbook");
+
+var api = builder.AddProject<Projects.Cookbook_Api>("api")
+    .WaitFor(postgres)
+    .WithReference(postgres);
 
 await builder.Build().RunAsync();

--- a/Cookbook-Api/Cookbook.AppHost/Properties/launchSettings.json
+++ b/Cookbook-Api/Cookbook.AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:44310;http://localhost:15298",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21040",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22134"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15298",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19014",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20279"
+      }
+    }
+  }
+}

--- a/Cookbook-Api/Cookbook.AppHost/appsettings.json
+++ b/Cookbook-Api/Cookbook.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/Cookbook-Api/Cookbook.Infrastructure/Cookbook.Infrastructure.csproj
+++ b/Cookbook-Api/Cookbook.Infrastructure/Cookbook.Infrastructure.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
+      <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
         <PrivateAssets>all</PrivateAssets>
@@ -19,4 +20,5 @@
         <ProjectReference Include="..\Cookbook.Common\Cookbook.Common.csproj" />
         <ProjectReference Include="..\Cookbook.Domain\Cookbook.Domain.csproj" />
     </ItemGroup>
+
 </Project>

--- a/Cookbook-Api/Cookbook.Infrastructure/Cookbook.Infrastructure.csproj
+++ b/Cookbook-Api/Cookbook.Infrastructure/Cookbook.Infrastructure.csproj
@@ -2,6 +2,7 @@
 
     <ItemGroup>
       <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
+      <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="9.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
         <PrivateAssets>all</PrivateAssets>

--- a/Cookbook-Api/Cookbook.Infrastructure/Persistence/PersistenceExtensions.cs
+++ b/Cookbook-Api/Cookbook.Infrastructure/Persistence/PersistenceExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,6 +18,13 @@ public static class PersistenceExtensions
         });
 
         builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
+
+        return builder;
+    }
+
+    public static WebApplicationBuilder AddRedisOutputCache(this WebApplicationBuilder builder)
+    {
+        builder.AddRedisOutputCache(connectionName: "redis");
 
         return builder;
     }

--- a/Cookbook-Api/Cookbook.Infrastructure/Persistence/PersistenceExtensions.cs
+++ b/Cookbook-Api/Cookbook.Infrastructure/Persistence/PersistenceExtensions.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,5 +27,15 @@ public static class PersistenceExtensions
         builder.AddRedisOutputCache(connectionName: "redis");
 
         return builder;
+    }
+
+    public static async Task ApplyMigrations(this IApplicationBuilder app)
+    {
+        using var scope = app.ApplicationServices.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        if (!(await dbContext.Database.GetPendingMigrationsAsync()).Any()) return;
+
+        await dbContext.Database.MigrateAsync();
     }
 }

--- a/Cookbook-Api/Cookbook.Infrastructure/Persistence/PersistenceExtensions.cs
+++ b/Cookbook-Api/Cookbook.Infrastructure/Persistence/PersistenceExtensions.cs
@@ -1,27 +1,24 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Cookbook.Infrastructure.Persistence;
 
 public static class PersistenceExtensions
 {
-    public static IServiceCollection AddPersistence(this IServiceCollection services, string connectionString)
+    public static WebApplicationBuilder AddPersistence(this WebApplicationBuilder builder)
     {
-        services.AddDbContext<AppDbContext>(builder => builder.ConfigureDbContext(connectionString));
-        services.AddScoped<IUnitOfWork, UnitOfWork>();
+        builder.AddNpgsqlDbContext<AppDbContext>(connectionName: "postgres", configureDbContextOptions: options =>
+        {
+            options.ConfigureWarnings(x => x.Throw(RelationalEventId.MultipleCollectionIncludeWarning));
+            options.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
+            options.UseNpgsql(opt => opt.ConfigureDataSource(x => x.EnableDynamicJson()));
+        });
 
-        return services;
+        builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
+
+        return builder;
     }
-    private static void ConfigureDbContext(this DbContextOptionsBuilder builder, string connectionString) =>
-         builder
-             .UseNpgsql(connectionString, options =>
-             {
-                 options.ConfigureDataSource(dataSourceOptions =>
-                 {
-                     dataSourceOptions.EnableDynamicJson();
-                 });
-             })
-             .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
-             .ConfigureWarnings(x => x.Throw(RelationalEventId.MultipleCollectionIncludeWarning));
 }

--- a/Cookbook-Api/Cookbook.ServiceDefaults/Cookbook.ServiceDefaults.csproj
+++ b/Cookbook-Api/Cookbook.ServiceDefaults/Cookbook.ServiceDefaults.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsAspireSharedProject>true</IsAspireSharedProject>
+        <IsAspireProjectResource>false</IsAspireProjectResource>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0"/>
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0"/>
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0"/>
+    </ItemGroup>
+
+</Project>

--- a/Cookbook-Api/Cookbook.ServiceDefaults/Extensions.cs
+++ b/Cookbook-Api/Cookbook.ServiceDefaults/Extensions.cs
@@ -1,0 +1,119 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+public static class Extensions
+{
+    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.AddServiceDiscovery();
+        });
+
+        // Uncomment the following to restrict the allowed schemes for service discovery.
+        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+        // {
+        //     options.AllowedSchemes = ["https"];
+        // });
+
+        return builder;
+    }
+
+    public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation()
+                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                    //.AddGrpcClientInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks("/health");
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks("/alive", new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}

--- a/Cookbook-Api/Cookbook.sln
+++ b/Cookbook-Api/Cookbook.sln
@@ -14,6 +14,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cookbook.Repositories", "Co
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cookbook.Tests", "Cookbook.Tests\Cookbook.Tests.csproj", "{E5555748-C077-4164-A69A-3D797244CBC5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cookbook.AppHost", "Cookbook.AppHost\Cookbook.AppHost.csproj", "{4A7A7A3F-36C9-44AD-A388-34D1ED7197C2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cookbook.ServiceDefaults", "Cookbook.ServiceDefaults\Cookbook.ServiceDefaults.csproj", "{1CE04216-3E28-48E7-BC12-0D6144088A4E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,5 +52,13 @@ Global
 		{E5555748-C077-4164-A69A-3D797244CBC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E5555748-C077-4164-A69A-3D797244CBC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E5555748-C077-4164-A69A-3D797244CBC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A7A7A3F-36C9-44AD-A388-34D1ED7197C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A7A7A3F-36C9-44AD-A388-34D1ED7197C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A7A7A3F-36C9-44AD-A388-34D1ED7197C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A7A7A3F-36C9-44AD-A388-34D1ED7197C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1CE04216-3E28-48E7-BC12-0D6144088A4E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1CE04216-3E28-48E7-BC12-0D6144088A4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1CE04216-3E28-48E7-BC12-0D6144088A4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1CE04216-3E28-48E7-BC12-0D6144088A4E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Cookbook-Api/Directory.Build.props
+++ b/Cookbook-Api/Directory.Build.props
@@ -4,5 +4,6 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <UserSecretsId>769482e3-040b-4429-b187-117afe953f92</UserSecretsId>
     </PropertyGroup>
 </Project>

--- a/Cookbook-Api/global.json
+++ b/Cookbook-Api/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
This pull request includes significant changes to the `Cookbook-Api` project, primarily focusing on adding service defaults, enhancing caching mechanisms, and improving project structure. The most important changes include adding a new project reference for service defaults, implementing output caching for endpoints, and restructuring the persistence layer.

### Enhancements to service defaults and caching:

* [`Cookbook-Api/Cookbook.Api/Cookbook.Api.csproj`](diffhunk://#diff-655c9396ce384c923ffff856da9245e2ce635a8a241d3b513e976b4d1875bb35R20): Added a project reference to `Cookbook.ServiceDefaults.csproj` to include common service configurations.
* [`Cookbook-Api/Cookbook.Api/Endpoints/Recipe/RecipeEndpoint.cs`](diffhunk://#diff-4171a23bd3c7b078e2b2e5827ab8823e98e4361ded90196696318567f1a84587R9): Added `Microsoft.AspNetCore.OutputCaching` and implemented `.CacheOutput()` for caching endpoint responses. [[1]](diffhunk://#diff-4171a23bd3c7b078e2b2e5827ab8823e98e4361ded90196696318567f1a84587R9) [[2]](diffhunk://#diff-4171a23bd3c7b078e2b2e5827ab8823e98e4361ded90196696318567f1a84587R31) [[3]](diffhunk://#diff-4171a23bd3c7b078e2b2e5827ab8823e98e4361ded90196696318567f1a84587R46)
* [`Cookbook-Api/Cookbook.Api/Program.cs`](diffhunk://#diff-4f74a0c25001ee988909d6a7c3ff3a9a2a71289a3a11b9292e3af729c787c05bL5-R26): Added `AddServiceDefaults`, `AddPersistence`, and `AddRedisOutputCache` methods to configure services and applied migrations on startup. [[1]](diffhunk://#diff-4f74a0c25001ee988909d6a7c3ff3a9a2a71289a3a11b9292e3af729c787c05bL5-R26) [[2]](diffhunk://#diff-4f74a0c25001ee988909d6a7c3ff3a9a2a71289a3a11b9292e3af729c787c05bR40)

### Project structure improvements:

* [`Cookbook-Api/Cookbook.AppHost/Cookbook.AppHost.csproj`](diffhunk://#diff-8e45fc103831898720e822a68c21ddf3c57f01ab5f3a220f0dcaabb7dbc67722R1-R21): Created a new project for hosting configurations and added necessary package references.
* [`Cookbook-Api/Cookbook.AppHost/Program.cs`](diffhunk://#diff-1dec2732c934e458ec0821afe272c37056f35fdf456772689cff4880400afd34R1-R19): Set up the distributed application builder with PostgreSQL and Redis configurations.
* [`Cookbook-Api/Cookbook.sln`](diffhunk://#diff-ca56a455d1cf9d6709993ed3a8196c971c387bc5bb1e688f9c99ac855ec22b2fR17-R20): Added `Cookbook.AppHost` and `Cookbook.ServiceDefaults` projects to the solution. [[1]](diffhunk://#diff-ca56a455d1cf9d6709993ed3a8196c971c387bc5bb1e688f9c99ac855ec22b2fR17-R20) [[2]](diffhunk://#diff-ca56a455d1cf9d6709993ed3a8196c971c387bc5bb1e688f9c99ac855ec22b2fR55-R62)

### Configuration and settings updates:

* [`Cookbook-Api/Cookbook.Api/appsettings.json`](diffhunk://#diff-c57252d6e19dcaa29054dd9449025a5b69f262fafbb3d4e46868f339da9c2c99L3-L5): Removed connection strings and updated settings for logging and service discovery.
* [`Cookbook-Api/Cookbook.AppHost/appsettings.json`](diffhunk://#diff-3a16684af6bfd876dda684a7b62dddbe12e274b1f6160e0c1d2b66364de82690R1-R9): Added logging configurations specific to the AppHost project.
* [`Cookbook-Api/global.json`](diffhunk://#diff-80171a7705b848106280879c1507a45c35fe24ead007fb2a17b0b4d8a8b7a739R1-R7): Specified the .NET SDK version and settings for the project.

### Persistence layer restructuring:

* [`Cookbook-Api/Cookbook.Infrastructure/Persistence/PersistenceExtensions.cs`](diffhunk://#diff-db085ada7450506538217682aed0c3ecc3f4ff5e90ba7924e9936af9e3c51e30L1-R40): Refactored `AddPersistence` to configure PostgreSQL and Redis output caching, and added a method to apply database migrations.

These changes collectively enhance the maintainability, performance, and scalability of the `Cookbook-Api` project.